### PR TITLE
Fix flex counters logic of converting poll interval to seconds from MS

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -933,7 +933,7 @@ void FlexCounter::addCounterPlugin(
             for (auto& sha: shaStrings)
             {
                 addRifCounterPlugin(sha);
-            } 
+            }
         }
         else if (field == BUFFER_POOL_PLUGIN_FIELD)
         {
@@ -1597,7 +1597,7 @@ void FlexCounter::runPlugins(
     {
         std::to_string(counters_db.getDbId()),
         COUNTERS_TABLE,
-        std::to_string(m_pollInterval * 1000)
+        std::to_string(m_pollInterval)
     };
 
     std::vector<std::string> portList;


### PR DESCRIPTION
According to https://github.com/Azure/SONiC/blob/ec6d35dd2c28491bfade19cfee990fe612f1e5e9/doc/rates-and-utilization/Rates_and_utilization_HLD.md, counterpoll command gives polling interval in milliseconds. 
So when converting them to seconds to be supplied to lua script this should be divide by 1000. However, syncd multiplies it by 1000.

Changed the multiplication to division.