### PR TITLE
[Mellanox] Add logic to use common sai.profile per asic for mlnx and nv bluefield

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -108,7 +108,7 @@ jobs:
       all_tests="${all_tests} p4rt dash"
       RETRY=3
       IMAGE_NAME=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber).asan-${{ parameters.asan }}
-      echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo ./run-tests.sh "$IMAGE_NAME" "$params" "TEST_MODULE" "$RETRY"
+      echo $all_tests | xargs -n 1 | xargs -P 8 -I TEST_MODULE sudo DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io/ ./run-tests.sh "$IMAGE_NAME" "$params" "TEST_MODULE" "$RETRY"
 
       rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -58,6 +58,21 @@ jobs:
     inputs:
       source: specific
       project: build
+      pipeline: Azure.sonic-buildimage.common_libs
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
+      artifact: common-lib
+      patterns: |
+        target/debs/bookworm/libyang-*_1.0*.deb
+        target/debs/bookworm/libyang_1.0*.deb
+        target/debs/bookworm/libyang-cpp_*.deb
+        target/debs/bookworm/python3-yang_*.deb
+    displayName: "Download libyang from common lib"
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: specific
+      project: build
       pipeline: sonic-net.sonic-buildimage-ubuntu22.04
       artifact: sonic-buildimage.amd64.ubuntu22_04
       runVersion: 'latestFromBranch'
@@ -85,10 +100,16 @@ jobs:
           libboost1.74-dev \
           libboost-dev \
           libhiredis0.14 \
-          libyang-dev \
+          libpcre3-dev \
           uuid-dev
 
       sudo sonic-sairedis/.azure-pipelines/build_and_install_module.sh
+
+      # Install libyang packages from downloaded artifacts
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang-*_1.0*.deb \
+                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang_1.0*.deb \
+                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/libyang-cpp_*.deb \
+                   $(Build.ArtifactStagingDirectory)/download/target/debs/bookworm/python3-yang_*.deb
 
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libprotobuf*_amd64.deb $(Build.ArtifactStagingDirectory)/download/libprotobuf-lite*_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-protobuf*_amd64.deb
       sudo apt install -y $(Build.ArtifactStagingDirectory)/download/libdashapi*.deb $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,4 @@
 	path = SAI
 	url = https://github.com/opencomputeproject/SAI.git
 	ignore = dirty
-	branch = v1.3
+	branch = v1.16

--- a/configure.ac
+++ b/configure.ac
@@ -283,7 +283,8 @@ AM_COND_IF([SAIVS],
     AM_COND_IF([SYNCD], [
     SAVED_FLAGS="$CXXFLAGS"
     CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
-    AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_query_stats_st_capability sai_tam_telemetry_get_data)
+    AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_tam_telemetry_get_data)
+    AH_TEMPLATE([HAVE_SAI_QUERY_STATS_ST_CAPABILITY], [Force it disabled for SAIs without implementation - REMOVE WHEN NOT NEEDED])
     CXXFLAGS="$SAVED_FLAGS"
     ])
 ])

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -30,6 +30,7 @@ static const std::string COUNTER_TYPE_ENI = "DASH ENI Counter";
 static const std::string COUNTER_TYPE_METER_BUCKET = "DASH Meter Bucket Counter";
 static const std::string COUNTER_TYPE_POLICER = "Policer Counter";
 static const std::string COUNTER_TYPE_SRV6 = "SRv6 Counter";
+static const std::string COUNTER_TYPE_SWITCH = "Switch Counter";
 static const std::string ATTR_TYPE_QUEUE = "Queue Attribute";
 static const std::string ATTR_TYPE_PG = "Priority Group Attribute";
 static const std::string ATTR_TYPE_MACSEC_SA = "MACSEC SA Attribute";
@@ -67,6 +68,7 @@ const std::map<std::tuple<sai_object_type_t, std::string>, std::string> FlexCoun
     {{(sai_object_type_t)SAI_OBJECT_TYPE_ENI, ENI_COUNTER_ID_LIST}, COUNTER_TYPE_ENI},
     {{(sai_object_type_t)SAI_OBJECT_TYPE_ENI, DASH_METER_COUNTER_ID_LIST}, COUNTER_TYPE_METER_BUCKET},
     {{SAI_OBJECT_TYPE_COUNTER, SRV6_COUNTER_ID_LIST}, COUNTER_TYPE_SRV6},
+    {{SAI_OBJECT_TYPE_SWITCH, SWITCH_COUNTER_ID_LIST}, COUNTER_TYPE_SWITCH},
 };
 
 BaseCounterContext::BaseCounterContext(const std::string &name, const std::string &instance):
@@ -2424,6 +2426,13 @@ std::shared_ptr<BaseCounterContext> FlexCounter::createCounterContext(
     {
         return std::make_shared<CounterContext<sai_counter_stat_t>>(context_name, instance, SAI_OBJECT_TYPE_COUNTER, m_vendorSai.get(), m_statsMode);
     }
+    else if (context_name == COUNTER_TYPE_SWITCH)
+    {
+        auto context = std::make_shared<CounterContext<sai_switch_stat_t>>(context_name, instance, SAI_OBJECT_TYPE_SWITCH, m_vendorSai.get(), m_statsMode);
+        context->always_check_supported_counters = true;
+        context->use_sai_stats_capa_query = true;
+        return context;
+    }
 
     SWSS_LOG_THROW("Invalid counter type %s", context_name.c_str());
     // GCC 8.3 requires a return value here
@@ -2664,6 +2673,10 @@ void FlexCounter::removeCounter(
         if (hasCounterContext(COUNTER_TYPE_SWITCH_DEBUG))
         {
             getCounterContext(COUNTER_TYPE_SWITCH_DEBUG)->removeObject(vid);
+        }
+        if (hasCounterContext(COUNTER_TYPE_SWITCH))
+        {
+            getCounterContext(COUNTER_TYPE_SWITCH)->removeObject(vid);
         }
     }
     else if (objectType == SAI_OBJECT_TYPE_MACSEC_FLOW)

--- a/syncd/SwitchNotifications.h
+++ b/syncd/SwitchNotifications.h
@@ -140,6 +140,10 @@ namespace syncd
                             .on_icmp_echo_session_state_change = &Slot<context>::onIcmpEchoSessionStateChange,
                             .on_extended_port_state_change = nullptr,
                             .on_tam_tel_type_config_change = &Slot<context>::onTamTelTypeConfigChange,
+                            .on_macsec_post_status = nullptr,
+                            .on_ipsec_post_status = nullptr,
+                            .on_switch_macsec_post_status = nullptr,
+                            .on_switch_ipsec_post_status = nullptr,
                             .on_ha_set_event = &Slot<context>::onHaSetEvent,
                             .on_ha_scope_event = &Slot<context>::onHaScopeEvent,
                             }) { }

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -536,18 +536,7 @@ config_syncd_xsight()
     LABEL_REVISION_FILE="/etc/sonic/hw_revision"
     ONIE_MACHINE=`sed -n -e 's/^.*onie_machine=//p' /etc/machine.conf`
 
-    ln -sf /usr/share/sonic/hwsku/xdrv_config.json /etc/xsight/xdrv_config.json
-    ln -sf /usr/share/sonic/hwsku/xlink_cfg.json /etc/xsight/xlink_cfg.json
-    ln -sf /usr/share/sonic/hwsku/lanes_polarity.json /etc/xsight/lanes_polarity.json
-
-    if [ -f  ${LABEL_REVISION_FILE} ]; then
-        LABEL_REVISION=`cat ${LABEL_REVISION_FILE}`
-        if [[ x${LABEL_REVISION} == x"R0B" ]] || [[ x${LABEL_REVISION} == x"R0B2" ]]; then
-            ln -sf /etc/xsight/serdes_config_A0.json /etc/xsight/serdes_config.json
-        else
-            ln -sf /etc/xsight/serdes_config_A1.json /etc/xsight/serdes_config.json
-        fi
-    fi
+    /usr/bin/init_xsai.sh
 
     #export XLOG_DEBUG="XSW SAI SAI-HOST XHAL-TBL XHAL-LKP XHAL-LPM XHAL-TCAM XHAL-DTE XHAL-RNG XHAL-SP XHAL-RPC"
     export XLOG_SYSLOG=ALL

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -349,6 +349,14 @@ config_syncd_mlnx()
 
     echo >> /tmp/sai-temp.profile
 
+    DEVICE_TYPE=$(/usr/bin/asic_detect/asic_detect.sh)
+    ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+    ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
+    if [ -f "$ASIC_PROFILE_PATH" ]; then
+        cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+        echo >> /tmp/sai-temp.profile
+    fi
+
     if [[ -f $SAI_COMMON_FILE_PATH ]]; then
         cat $SAI_COMMON_FILE_PATH >> /tmp/sai-temp.profile
     fi
@@ -509,7 +517,21 @@ config_syncd_nvidia_bluefield()
 
     eth0_mac=$(cat /sys/class/net/Ethernet0/address)
 
-    cp $HWSKU_DIR/sai.profile /tmp/sai.profile
+    cp $HWSKU_DIR/sai.profile /tmp/sai-temp.profile
+
+    echo >> /tmp/sai-temp.profile
+
+    DEVICE_TYPE=$(/usr/bin/asic_detect/asic_detect.sh)
+    ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+    ASIC_PROFILE_PATH="/etc/nv-bf/${ASIC_PROFILE_FILE}"
+    if [ -f "$ASIC_PROFILE_PATH" ]; then
+        cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+        echo >> /tmp/sai-temp.profile
+    fi
+
+    # keep only the first occurence of each prefix with '=' sign, and remove the others.
+    awk -F= '!seen[$1]++' /tmp/sai-temp.profile > /tmp/sai.profile
+    rm -f /tmp/sai-temp.profile
 
     # Update sai.profile with MAC_ADDRESS
     echo "DEVICE_MAC_ADDRESS=$base_mac" >> /tmp/sai.profile

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -350,11 +350,15 @@ config_syncd_mlnx()
     echo >> /tmp/sai-temp.profile
 
     DEVICE_TYPE=$(/usr/bin/asic_detect/asic_detect.sh)
-    ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
-    ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
-    if [ -f "$ASIC_PROFILE_PATH" ]; then
-        cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
-        echo >> /tmp/sai-temp.profile
+    if [[ $? -eq 0 ]]; then
+        ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+        ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
+        if [ -f "$ASIC_PROFILE_PATH" ]; then
+            cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+            echo >> /tmp/sai-temp.profile
+        fi
+    else
+        echo "Warning: ASIC is not detected..."
     fi
 
     if [[ -f $SAI_COMMON_FILE_PATH ]]; then
@@ -522,11 +526,15 @@ config_syncd_nvidia_bluefield()
     echo >> /tmp/sai-temp.profile
 
     DEVICE_TYPE=$(/usr/bin/asic_detect/asic_detect.sh)
-    ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
-    ASIC_PROFILE_PATH="/etc/nv-bf/${ASIC_PROFILE_FILE}"
-    if [ -f "$ASIC_PROFILE_PATH" ]; then
-        cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
-        echo >> /tmp/sai-temp.profile
+    if [[ $? -eq 0 ]]; then
+        ASIC_PROFILE_FILE="sai-${DEVICE_TYPE}.profile"
+        ASIC_PROFILE_PATH="/etc/mlnx/${ASIC_PROFILE_FILE}"
+        if [ -f "$ASIC_PROFILE_PATH" ]; then
+            cat "$ASIC_PROFILE_PATH" >> /tmp/sai-temp.profile
+            echo >> /tmp/sai-temp.profile
+        fi
+    else
+        echo "Warning: ASIC is not detected..."
     fi
 
     # keep only the first occurence of each prefix with '=' sign, and remove the others.

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -617,6 +617,68 @@ TEST(FlexCounter, addRemoveCounter)
         false,
         STATS_MODE_READ,
         true);
+
+    // Packet Trimming
+
+    testAddRemoveCounter(
+        1,
+        SAI_OBJECT_TYPE_PORT,
+        PORT_COUNTER_ID_LIST,
+        {"SAI_PORT_STAT_TRIM_PACKETS", "SAI_PORT_STAT_DROPPED_TRIM_PACKETS", "SAI_PORT_STAT_TX_TRIM_PACKETS"},
+        {"100", "200", "300"},
+        counterVerifyFunc,
+        false);
+
+    testAddRemoveCounter(
+        1,
+        SAI_OBJECT_TYPE_PORT,
+        PORT_COUNTER_ID_LIST,
+        {"SAI_PORT_STAT_TRIM_PACKETS", "SAI_PORT_STAT_DROPPED_TRIM_PACKETS", "SAI_PORT_STAT_TX_TRIM_PACKETS"},
+        {"100", "200", "300"},
+        counterVerifyFunc,
+        false,
+        STATS_MODE_READ,
+        true);
+
+    testAddRemoveCounter(
+        1,
+        SAI_OBJECT_TYPE_QUEUE,
+        QUEUE_COUNTER_ID_LIST,
+        {"SAI_QUEUE_STAT_TRIM_PACKETS", "SAI_QUEUE_STAT_DROPPED_TRIM_PACKETS", "SAI_QUEUE_STAT_TX_TRIM_PACKETS"},
+        {"100", "200", "300"},
+        counterVerifyFunc,
+        false);
+
+    testAddRemoveCounter(
+        1,
+        SAI_OBJECT_TYPE_QUEUE,
+        QUEUE_COUNTER_ID_LIST,
+        {"SAI_QUEUE_STAT_TRIM_PACKETS", "SAI_QUEUE_STAT_DROPPED_TRIM_PACKETS", "SAI_QUEUE_STAT_TX_TRIM_PACKETS"},
+        {"100", "200", "300"},
+        counterVerifyFunc,
+        false,
+        STATS_MODE_READ,
+        true);
+
+    testAddRemoveCounter(
+        1,
+        SAI_OBJECT_TYPE_SWITCH,
+        SWITCH_COUNTER_ID_LIST,
+        {"SAI_SWITCH_STAT_DROPPED_TRIM_PACKETS", "SAI_SWITCH_STAT_TX_TRIM_PACKETS"},
+        {"100", "200"},
+        counterVerifyFunc,
+        false);
+
+    testAddRemoveCounter(
+        1,
+        SAI_OBJECT_TYPE_SWITCH,
+        SWITCH_COUNTER_ID_LIST,
+        {"SAI_SWITCH_STAT_DROPPED_TRIM_PACKETS", "SAI_SWITCH_STAT_TX_TRIM_PACKETS"},
+        {"100", "200"},
+        counterVerifyFunc,
+        false,
+        STATS_MODE_READ,
+        true);
 }
 
 TEST(FlexCounter, UpdateExistingCounterAddBulk)
@@ -895,15 +957,15 @@ TEST(FlexCounter, bulkCounter)
     int counterOffset = 0;
     int capabilities = 0;
     sai->mock_queryStatsCapability = [&](sai_object_id_t switch_id, sai_object_type_t object_type, sai_stat_capability_list_t *stats_capability) {
-        // Assume all counters are in range [currentOffset, currentOffset + 100]
+        // Assume all counters are in range [currentOffset, currentOffset + 250]
         if (stats_capability->count == 0)
         {
-            stats_capability->count = 100;
+            stats_capability->count = 250;
             return SAI_STATUS_BUFFER_OVERFLOW;
         }
         else
         {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 250; i++)
 	    {
                 stats_capability->list[i].stat_enum = i + counterOffset;
                 if (capabilities == 0)
@@ -1092,6 +1154,35 @@ TEST(FlexCounter, bulkCounter)
         SAI_OBJECT_TYPE_COUNTER,
         SRV6_COUNTER_ID_LIST,
         {"SAI_COUNTER_STAT_PACKETS", "SAI_COUNTER_STAT_BYTES"},
+        {"100", "200"},
+        counterVerifyFunc,
+        false);
+
+    // Packet Trimming
+
+    testAddRemoveCounter(
+        2,
+        SAI_OBJECT_TYPE_PORT,
+        PORT_COUNTER_ID_LIST,
+        {"SAI_PORT_STAT_TRIM_PACKETS", "SAI_PORT_STAT_DROPPED_TRIM_PACKETS", "SAI_PORT_STAT_TX_TRIM_PACKETS"},
+        {"100", "200", "300"},
+        counterVerifyFunc,
+        false);
+
+    testAddRemoveCounter(
+        2,
+        SAI_OBJECT_TYPE_QUEUE,
+        QUEUE_COUNTER_ID_LIST,
+        {"SAI_QUEUE_STAT_TRIM_PACKETS", "SAI_QUEUE_STAT_DROPPED_TRIM_PACKETS", "SAI_QUEUE_STAT_TX_TRIM_PACKETS"},
+        {"100", "200", "300"},
+        counterVerifyFunc,
+        false);
+
+    testAddRemoveCounter(
+        2,
+        SAI_OBJECT_TYPE_SWITCH,
+        SWITCH_COUNTER_ID_LIST,
+        {"SAI_SWITCH_STAT_DROPPED_TRIM_PACKETS", "SAI_SWITCH_STAT_TX_TRIM_PACKETS"},
         {"100", "200"},
         counterVerifyFunc,
         false);

--- a/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
+++ b/unittest/vslib/TestVirtualSwitchSaiInterface.cpp
@@ -169,6 +169,25 @@ TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsCapability)
     std::vector<sai_stat_capability_t> capability_list;
     sai_stat_capability_list_t stats_capability;
 
+    /* Switch stats capability get */
+    stats_capability.count = 0;
+    stats_capability.list = nullptr;
+
+    EXPECT_EQ(SAI_STATUS_BUFFER_OVERFLOW,
+            m_vssai->queryStatsCapability(
+                m_swid,
+                SAI_OBJECT_TYPE_SWITCH,
+                &stats_capability));
+
+    capability_list.resize(stats_capability.count);
+    stats_capability.list = capability_list.data();
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS,
+            m_vssai->queryStatsCapability(
+                m_swid,
+                SAI_OBJECT_TYPE_SWITCH,
+                &stats_capability));
+
     /* Queue stats capability get */
     stats_capability.count = 0;
     stats_capability.list = nullptr;
@@ -212,6 +231,25 @@ TEST_F(VirtualSwitchSaiInterfaceTest, queryStatsStCapability)
 {
     std::vector<sai_stat_st_capability_t> capability_list;
     sai_stat_st_capability_list_t stats_capability;
+
+    /* Switch stats capability get */
+    stats_capability.count = 0;
+    stats_capability.list = nullptr;
+
+    EXPECT_EQ(SAI_STATUS_BUFFER_OVERFLOW,
+              m_vssai->queryStatsStCapability(
+                  m_swid,
+                  SAI_OBJECT_TYPE_SWITCH,
+                  &stats_capability));
+
+    capability_list.resize(stats_capability.count);
+    stats_capability.list = capability_list.data();
+
+    EXPECT_EQ(SAI_STATUS_SUCCESS,
+              m_vssai->queryStatsStCapability(
+                  m_swid,
+                  SAI_OBJECT_TYPE_SWITCH,
+                  &stats_capability));
 
     /* Queue stats capability get */
     stats_capability.count = 0;

--- a/vslib/SwitchStateBase.h
+++ b/vslib/SwitchStateBase.h
@@ -771,6 +771,9 @@ namespace saivs
 
         protected:
 
+            virtual sai_status_t querySwitchStatsCapability(
+                                      _Inout_ sai_stat_capability_list_t *stats_capability);
+
             virtual sai_status_t queryPortStatsCapability(
                                       _Inout_ sai_stat_capability_list_t *stats_capability);
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -3629,7 +3629,7 @@ static u8 translate_sr_behavior(u32 behavior)
             return SR_BEHAVIOR_API_DT4;
             break;
         case SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN:
-            return SR_BEHAVIOR_API_END_UN_PERF;
+            return SR_BEHAVIOR_API_END_UN;
             break;
         case SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA:
             return SR_BEHAVIOR_API_UA;


### PR DESCRIPTION
Changed config_mlnx_syncd() and config_syncd_nvidia_bluefield() functionality to use per-asic sai.profile for all Spectrum{x} SKUs.
The function will apply specific SKU sai.profile, then per-asic sai.profile and lastly - sai-common.profile (which is for all Mellanox SKUs).

Why I did it
To have the ability to add common parameters to only 1 file instead of all SKUs - but per asic.

depends on https://github.com/noaOrMlnx/sonic-buildimage/pull/67 that created asic_detect.sh.